### PR TITLE
Fix bug back in creating challenge

### DIFF
--- a/components/CreateChallenge/Form03ChallengeRepeat.tsx
+++ b/components/CreateChallenge/Form03ChallengeRepeat.tsx
@@ -24,6 +24,9 @@ import Colors from '../../variablesColors';
 
 function Form03ChallengeRepeat({navigation, route}, props) {
   const state = useStore(state => state);
+  useEffect(() => {
+    state.setChallengeType('repeat');
+  }, []);
 
   return (
     <Container style={styles.Container}>

--- a/components/CreateChallenge/Form03ChallengeRepeat.tsx
+++ b/components/CreateChallenge/Form03ChallengeRepeat.tsx
@@ -24,6 +24,7 @@ import Colors from '../../variablesColors';
 
 function Form03ChallengeRepeat({navigation, route}, props) {
   const state = useStore(state => state);
+  
   useEffect(() => {
     state.setChallengeType('repeat');
   }, []);

--- a/components/CreateChallenge/FormGroup03ChallengeRepeat.tsx
+++ b/components/CreateChallenge/FormGroup03ChallengeRepeat.tsx
@@ -25,7 +25,10 @@ import Colors from '../../variablesColors';
 function FormGroup03ChallengeRepeat({navigation, route}, props) {
   const state = useStore(state => state);
 
-  console.log('state in Form03ChallengeRepeattsx: ', state);
+  useEffect(() => {
+    state.setChallengeType('repeat');
+  }, []);
+
   return (
     <Container style={styles.Container}>
       <Content padder>

--- a/components/CreateChallenge/FormGroup04ChallengeConfirmation.tsx
+++ b/components/CreateChallenge/FormGroup04ChallengeConfirmation.tsx
@@ -173,64 +173,51 @@ function FormGroup04ChallengeConfirmation({navigation, route}, props) {
     task30Date: getDateOfChallenge(30),
   };
   const insertChallenge = () => {
-    console.log('createNewGroupAndChallenge:  ********  ', challengeInput);
-    console.log('groupInput:  ********  ', groupInput);
-    console.log('challengeInput:  ********  ', challengeInput);
     API.graphql(
       graphqlOperation(customMutations.createNewGroupAndChallenge, {
         inputGroup: groupInput,
         inputChallenge: challengeInput,
       }),
     )
-      .then(resultIds => {
-        console.log('res.data.createGroup.id :', resultIds.data.createGroup.id);
-        console.log(
-          'resultIds.data.createChallenge.id :',
-          resultIds.data.createChallenge.id,
-        );
-        state.setChallengeInput({
-          ...state.challengeInput,
-          groupId: resultIds.data.createGroup.id,
-        });
-        console.log('groupChallengeInput:  ********  ', {
-          ...groupChallengeInput,
-          challengeId: resultIds.data.createChallenge.id,
-          groupId: resultIds.data.createGroup.id,
-        });
+    .then(resultIds => {
+      state.setChallengeInput({
+        ...state.challengeInput,
+        groupId: resultIds.data.createGroup.id,
+      });
 
-        API.graphql(
-          graphqlOperation(mutations.createGroupChallenge, {
-            input: {
-              ...groupChallengeInput,
-              challengeId: resultIds.data.createChallenge.id,
-              groupId: resultIds.data.createGroup.id,
-            },
-          }),
-        )
-          .then(res => {
-            state.setUserHasActiveChallenge(true);
-            state.setUserActiveChallengesList([
-              ...state.userActiveChallengesList,
-              res.data.createGroupChallenge,
-            ]);
-            LocalPushNotificationSetting.register(
-              9,
-              0,
-              0,
-              'You have a daily goal to complete',
-              21,
-              0,
-              0,
-              'Did you complete your goal for today?',
-            );
-          })
-          .catch(error =>
-            console.log('Error happens in createGroupChallenge : ', error),
-          );
+      API.graphql(
+        graphqlOperation(mutations.createGroupChallenge, {
+          input: {
+            ...groupChallengeInput,
+            challengeId: resultIds.data.createChallenge.id,
+            groupId: resultIds.data.createGroup.id,
+          },
+        }),
+      )
+      .then(res => {
+        state.setUserHasActiveChallenge(true);
+        state.setUserActiveChallengesList([
+          ...state.userActiveChallengesList,
+          res.data.createGroupChallenge,
+        ]);
+        LocalPushNotificationSetting.register(
+          9,
+          0,
+          0,
+          'You have a daily goal to complete',
+          21,
+          0,
+          0,
+          'Did you complete your goal for today?',
+        );
       })
       .catch(error =>
-        console.log('Error happens in createNewGroupAndChallenge: ', error),
+        console.log('Error happens in createGroupChallenge : ', error),
       );
+    })
+    .catch(error =>
+      console.log('Error happens in createNewGroupAndChallenge: ', error),
+    );
   };
 
   return (
@@ -264,7 +251,6 @@ function FormGroup04ChallengeConfirmation({navigation, route}, props) {
           title="Start Challenge"
           onPress={() => {
             insertChallenge();
-            // props.changeView();
             navigation.navigate('GroupChallengeSharingInformation');
           }}>
           <Text>Save Group Challenge</Text>


### PR DESCRIPTION
Before: When users create new challenge, if users firstly choose library type and change to repeat type, task name is 'undefined'. 
After: When users create new challenge, if users firstly choose library type and change to repeat type, task name is the one users created.